### PR TITLE
Add README with installation and usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# aliaser
+
+`aliaser` provides a small metaclass and mixin that let you declare call-perfect
+aliases for methods. Apply the `@alias` decorator to a method to expose it under
+multiple names, or use `AliasMixin.add_alias` at runtime to add new aliases.
+Importing the package automatically registers the `alias` decorator under
+`builtins` so it is always available.
+
+## Installation
+
+Install from PyPI with `pip`:
+
+```bash
+pip install aliaser
+```
+
+Or add it to a Poetry project:
+
+```bash
+poetry add aliaser
+```
+
+## Usage
+
+### Declaring aliases with `@alias`
+
+```python
+from aliaser import Aliases, alias
+
+class Greeter(Aliases):
+    @alias('hi', 'sup')
+    def hello(self):
+        print("Hello!")
+
+Greeter().hi()  # prints "Hello!"
+```
+
+### Adding aliases at runtime
+
+```python
+Greeter.add_alias('hello', 'howdy')
+Greeter().howdy()  # also prints "Hello!"
+```
+
+Importing `aliaser` adds the `alias` decorator to `builtins`, so it can be used
+without an explicit import once the package is imported.
+
+## Contributing
+
+Contributions are welcome! Please open an issue or submit a pull request on
+GitHub to discuss changes.
+
+## Supported Python versions
+
+This package requires Python 3.12 or newer.
+
+## License
+
+`aliaser` is distributed under the terms of the MIT License.
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `aliaser` provides a small metaclass and mixin that let you declare call-perfect
 aliases for methods. Apply the `@alias` decorator to a method to expose it under
-multiple names, or use `AliasMixin.add_alias` at runtime to add new aliases.
+multiple names, or use `Aliases.add_alias` at runtime to add new aliases.
 Importing the package automatically registers the `alias` decorator under
 `builtins` so it is always available.
 
@@ -44,6 +44,10 @@ Greeter().howdy()  # also prints "Hello!"
 
 Importing `aliaser` adds the `alias` decorator to `builtins`, so it can be used
 without an explicit import once the package is imported.
+
+This modifies the global namespace. If you prefer to avoid that side effect,
+import `alias` from `aliaser.decorator` and `Aliases` from `aliaser.mixin`
+directly instead of importing the top-level package.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- document the purpose of **aliaser**
- outline pip/poetry installation steps
- show how to use `@alias` and `AliasMixin.add_alias`
- note automatic registration of `alias` on `builtins`
- add contribution notes, Python support, and license info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686abefab0a0832dad7e5bb31c31004d

## Summary by Sourcery

Documentation:
- Add README with project purpose, pip/poetry installation steps, usage examples for @alias and runtime aliasing, contribution notes, supported Python versions, and MIT license information.