### PR TITLE
Fix unused import

### DIFF
--- a/aliaser/decorator.py
+++ b/aliaser/decorator.py
@@ -1,7 +1,7 @@
 """Utility decorator for exposing a method under multiple names."""
 from __future__ import annotations
 from types import FunctionType
-from typing import Callable, Iterable, Hashable
+from typing import Callable, Hashable
 
 
 def alias(*names: Hashable) -> Callable[[FunctionType], FunctionType]:


### PR DESCRIPTION
## Summary
- remove unused `Iterable` import from decorator module

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b3afba5a8832d8163c166f42432f6

## Summary by Sourcery

Chores:
- Removed unused Iterable import from aliaser/decorator.py