### PR TITLE
Fix metaclass docstring spacing

### DIFF
--- a/aliaser/metaclass.py
+++ b/aliaser/metaclass.py
@@ -1,6 +1,5 @@
 """Metaclass that injects method aliases declared via :func:`aliaser.decorator.alias`."""
 
-
 class AliasMeta(type):
     """Metaclass that injects method aliases declared via ``@alias``."""
 


### PR DESCRIPTION
## Summary
- trim extra newline after the metaclass module docstring

## Testing
- `pytest -q`
- `python -m pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_686b3cc3db6c832da3dc5aeaeaa5e768

## Summary by Sourcery

Documentation:
- Remove redundant newline following the metaclass module docstring