### PR TITLE
Update __all__ exports

### DIFF
--- a/aliaser/__init__.py
+++ b/aliaser/__init__.py
@@ -15,4 +15,4 @@ if not hasattr(_bt, "alias"):
     _bt.alias = alias
 
 
-__all__ = ['Aliases']
+__all__ = ['Aliases', 'alias']


### PR DESCRIPTION
## Summary
- export `alias` at package level so `from aliaser import *` works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b3dc5c890832dbbdf775095773d22

## Summary by Sourcery

Enhancements:
- Add `alias` to the `__all__` list in `aliaser/__init__.py` to enable `from aliaser import *` to include the function.