### PR TITLE
Add install/uninstall helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ method aliases without writing boilerplate forwarders.
 - `@alias` decorator to expose a method or property under multiple names.
 - `Aliases` mixin for runtime helpers, backed by the `AliasMeta` metaclass.
 - Property and method aliases share the original descriptor – no wrappers.
-- Automatically registers `alias` on `builtins` when importing the package for
-  drop-in usage.
+- `install()`/`uninstall()` helpers manage registration of `alias` on
+  `builtins`. `install()` runs automatically on import for drop-in usage.
 
 ## Installation
 
@@ -61,10 +61,11 @@ Greeter().howdy()  # also prints "Hello!"
 
 ### Avoiding the built-ins side effect
 
-Importing the top-level package registers `alias` on `builtins` so it can be
-used without an explicit import. This modifies the global namespace. To avoid
-that side effect, import `alias` from `aliaser.decorator` and `Aliases` from
-`aliaser.mixin` directly instead of importing `aliaser`.
+Importing the top-level package calls `aliaser.install()` which registers
+`alias` on `builtins`. This modifies the global namespace. Call
+`aliaser.uninstall()` to undo the side effect, or import `alias` from
+`aliaser.decorator` and `Aliases` from `aliaser.mixin` directly instead of
+importing `aliaser`.
 
 ## Development
 

--- a/aliaser/__init__.py
+++ b/aliaser/__init__.py
@@ -1,18 +1,27 @@
-"""Initialize the package and inject the ``alias`` decorator into ``builtins``.
+"""Package initialization and built-in ``alias`` management."""
 
-This module exposes the :func:`aliaser.decorator.alias` decorator and the
-:class:`aliaser.mixin.AliasMixin` class.  It also registers ``alias`` on the
-``builtins`` module if it does not already exist so it can be used without an
-explicit import.
-"""
 import builtins as _bt
+
 from .decorator import alias
 from .mixin import AliasMixin as Aliases
 
 
-# Avoid clobbering existing names
-if not hasattr(_bt, "alias"):
-    _bt.alias = alias
+def install() -> None:
+    """Inject :func:`alias` into :mod:`builtins` if not already present."""
+
+    if not hasattr(_bt, "alias"):
+        _bt.alias = alias
 
 
-__all__ = ['Aliases', 'alias']
+def uninstall() -> None:
+    """Remove :func:`alias` from :mod:`builtins` when installed."""
+
+    if getattr(_bt, "alias", None) is alias:
+        delattr(_bt, "alias")
+
+
+# Backwards compatibility – automatically expose ``alias`` on import
+install()
+
+
+__all__ = ["Aliases", "alias", "install", "uninstall"]


### PR DESCRIPTION
## Summary
- add install() & uninstall() functions
- call install() at import time for backward compatibility
- document the new functions

## Testing
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_686b3fb1fbb8832dbc57e3d46bdb9718

## Summary by Sourcery

Add install/uninstall helpers for managing the global alias decorator, refactor existing builtins injection into these functions, and update documentation accordingly.

New Features:
- Add install() and uninstall() helper functions to register and unregister the alias decorator on builtins

Enhancements:
- Refactor top-level builtins alias injection into the new install/uninstall functions
- Automatically invoke install() at import time for backward compatibility
- Expose install and uninstall in __all__

Documentation:
- Update README to document the install()/uninstall() helpers and recommended usage