### PR TITLE
Add Sphinx docs with Read the Docs config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.egg
+
+# Sphinx build directory
+/docs/_build/
+/dist/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+version: 2
+sphinx:
+  configuration: docs/conf.py
+python:
+  install:
+    - path: .
+      extra_requirements:
+        - docs
+

--- a/demo/example.ipynb
+++ b/demo/example.ipynb
@@ -1,0 +1,108 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "F8GFzFCi7Hy_",
+        "outputId": "376df031-b25f-4479-d57f-2cfe88e9d9e3"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Collecting aliaser==1.0.0-dev.2\n",
+            "  Downloading aliaser-1.0.0.dev2-py3-none-any.whl.metadata (632 bytes)\n",
+            "Downloading aliaser-1.0.0.dev2-py3-none-any.whl (3.6 kB)\n",
+            "Installing collected packages: aliaser\n",
+            "Successfully installed aliaser-1.0.0.dev2\n"
+          ]
+        }
+      ],
+      "source": [
+        "!pip install aliaser==1.0.0-dev.2"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from aliaser import Aliases\n",
+        "from datetime import datetime\n",
+        "\n",
+        "class Example(Aliases):\n",
+        "    def __init__(self):\n",
+        "        self._start_time = datetime.now()\n",
+        "\n",
+        "    @property\n",
+        "    @alias('start_ts', 'start_timestamp')\n",
+        "    def start_time(self):\n",
+        "        return self._start_time\n",
+        "\n",
+        "    @alias('get_ts', 'get_timestamp', 'now')\n",
+        "    def get_time(self):\n",
+        "        return datetime.now()\n",
+        "\n",
+        "\n",
+        "EXAMPLE = Example()\n",
+        ""
+      ],
+      "metadata": {
+        "id": "PLYGiNg77M-U"
+      },
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(EXAMPLE.now())\n",
+        "print(EXAMPLE.start_ts)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "lLCAAa6Z7tv8",
+        "outputId": "bba3ad71-4b1e-46e4-a884-95bb380fbc85"
+      },
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "2025-07-06 22:53:32.195644\n",
+            "2025-07-06 22:50:19.033539\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "5pVwKG-S7y9P"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/aliaser.rst
+++ b/docs/aliaser.rst
@@ -1,0 +1,37 @@
+aliaser package
+===============
+
+Submodules
+----------
+
+aliaser.decorator module
+------------------------
+
+.. automodule:: aliaser.decorator
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aliaser.metaclass module
+------------------------
+
+.. automodule:: aliaser.metaclass
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aliaser.mixin module
+--------------------
+
+.. automodule:: aliaser.mixin
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: aliaser
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,7 @@
+API Reference
+=============
+
+.. automodule:: aliaser
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,37 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'aliaser'
+copyright = '2025, Taylor B.'
+author = 'Taylor B.'
+
+version = '1.0.0'
+release = '1.0.0'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'furo'
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,16 @@
+.. aliaser documentation master file, created by
+   sphinx-quickstart on Mon Jul  7 03:37:27 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+aliaser documentation
+=====================
+
+Welcome to the documentation for **aliaser**.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   api
+

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,7 @@
+aliaser
+=======
+
+.. toctree::
+   :maxdepth: 4
+
+   aliaser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ requires-python = ">=3.12"
 dependencies = [
 ]
 
+[project.optional-dependencies.docs]
+sphinx = "^8.0"
+furo = "^2024.8.6"
+
 [tool.poetry]
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,17 @@
 [project]
 name = "aliaser"
-version = "1.0.0-dev.1"
+version = "1.0.0-dev.3"
 description = "Drop-in mix-in + metaclass that let you declare any number of call-perfect aliases for a method with a single decorator or a runtime helper. No boiler-plate forwarders required."
 authors = [
     {name = "Taylor B.",email = "t.blackstone@inspyre.tech"}
 ]
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 dependencies = [
 ]
 
-[project.optional-dependencies.docs]
+[toool.poetry.group.docs.dependencies]
 sphinx = "^8.0"
 furo = "^2024.8.6"
 
@@ -21,6 +21,11 @@ furo = "^2024.8.6"
 ipython = "^9.4.0"
 prompt-toolkit = "^3.0.51"
 ptipython = "^1.0.1"
+
+
+[tool.poetry.group.docs.dependencies]
+sphinx = "^8.2.3"
+furo = "^2024.8.6"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]


### PR DESCRIPTION
## Summary
- add a docs folder with basic Sphinx configuration
- configure project to use Furo theme and napoleon extension
- add optional `docs` dependencies to `pyproject.toml`
- add `.readthedocs.yml` for building docs on Read the Docs
- add `.gitignore` for build artifacts

## Testing
- `sphinx-build -b html docs docs/_build/html`

------
https://chatgpt.com/codex/tasks/task_e_686b409bc880832d8eabc4f7e1d0f39c

## Summary by Sourcery

Set up Sphinx-based documentation with Read the Docs integration, add optional docs dependencies and example notebook, and update project metadata.

New Features:
- Add example Jupyter notebook demonstrating aliaser usage

Enhancements:
- Define optional 'docs' extras in pyproject.toml for Sphinx and Furo dependencies
- Bump project version to 1.0.0-dev.3 and lower Python requirement to >=3.11

CI:
- Add Read the Docs configuration via .readthedocs.yml

Documentation:
- Introduce Sphinx documentation scaffold with conf.py, Makefile, and RST stubs using Furo theme and Napoleon extension

Chores:
- Add .gitignore entries to exclude documentation build artifacts