### PR TITLE
Add documentation pages

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,0 +1,14 @@
+Development
+===========
+
+To set up a local development environment clone the repository and install
+its dependencies with Poetry:
+
+.. code-block:: bash
+
+   poetry install
+
+After making changes you can build the wheel with ``poetry build``.
+Feel free to open issues or pull requests on GitHub to discuss
+improvements.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,5 +12,8 @@ Welcome to the documentation for **aliaser**.
    :maxdepth: 2
    :caption: Contents:
 
+   installation
+   usage
+   development
    api
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,15 @@
+Installation
+============
+
+Install ``aliaser`` from PyPI with ``pip``:
+
+.. code-block:: bash
+
+   pip install aliaser
+
+Alternatively, add it to a Poetry project:
+
+.. code-block:: bash
+
+   poetry add aliaser
+

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,36 @@
+Usage
+=====
+
+This section demonstrates common ways to declare and work with method aliases.
+
+Declaring aliases with ``@alias``
+---------------------------------
+
+.. code-block:: python
+
+   from aliaser import Aliases, alias
+
+   class Greeter(Aliases):
+       @alias('hi', 'sup')
+       def hello(self):
+           print("Hello!")
+
+   Greeter().hi()  # prints "Hello!"
+
+Adding aliases at runtime
+-------------------------
+
+.. code-block:: python
+
+   Greeter.add_alias('hello', 'howdy')
+   Greeter().howdy()  # also prints "Hello!"
+
+Avoiding the built-ins side effect
+----------------------------------
+
+Importing the top-level package calls :func:`aliaser.install` which registers
+``alias`` on ``builtins``. This modifies the global namespace. Call
+:func:`aliaser.uninstall` to undo the side effect, or import :func:`alias` from
+``aliaser.decorator`` and :class:`aliaser.mixin.AliasMixin` directly instead of
+importing ``aliaser``.
+


### PR DESCRIPTION
## Summary
- extend docs index to reference new pages
- add installation, usage, and development pages for Read the Docs

## Testing
- `pip install sphinx furo`
- `make html`

------
https://chatgpt.com/codex/tasks/task_e_686b45ff0dc8832dac7169db9d39cb31

## Summary by Sourcery

Add new documentation pages and update the docs index to reference them

Documentation:
- Add installation guide page
- Add usage guide page
- Add development guide page
- Update index.rst to include links to the new pages