### PR TITLE
Fix docs build by providing Furo dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,11 @@ requires-python = ">=3.11"
 dependencies = [
 ]
 
-[toool.poetry.group.docs.dependencies]
-sphinx = "^8.0"
-furo = "^2024.8.6"
+[project.optional-dependencies]
+docs = [
+    "sphinx>=8.2.3",
+    "furo>=2024.8.6",
+]
 
 [tool.poetry]
 


### PR DESCRIPTION
## Summary
- ensure docs optional dependencies include the Furo theme

## Testing
- `sphinx-build -b html docs docs/_build/html`

------
https://chatgpt.com/codex/tasks/task_e_686b4907f63c832da7dfee26d70d3b8a

## Summary by Sourcery

Refactor pyproject.toml to define documentation dependencies under PEP 621 optional-dependencies and include the Furo Sphinx theme.

Enhancements:
- Move Sphinx and Furo dependencies into project.optional-dependencies.docs

Build:
- Add furo>=2024.8.6 to docs optional dependencies
- Bump sphinx requirement to >=8.2.3