### PR TITLE
Add missing PyPI classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,19 @@ requires-python = ">=3.11"
 dependencies = [
 ]
 
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+
 [project.optional-dependencies]
 docs = [
     "sphinx>=8.2.3",


### PR DESCRIPTION
## Summary
- list relevant PyPI classifiers in `pyproject.toml`

## Testing
- `poetry build`
- `pip install -e .`


------
https://chatgpt.com/codex/tasks/task_e_686b5594630c832db712555d1f39bd83

## Summary by Sourcery

Enhancements:
- Add relevant PyPI classifiers for development status, audience, license, OS compatibility, supported Python versions, topic, and typing in pyproject.toml metadata.