### PR TITLE
Address review feedback on MultitonMeta

### DIFF
--- a/aliaser/metaclass/alias.py
+++ b/aliaser/metaclass/alias.py
@@ -1,20 +1,4 @@
-"""
-
-
-Author: 
-    Inspyre Softworks
-
-Project:
-    aliaser
-
-File: 
-    aliaser/metaclass/alias.py
- 
-
-Description:
-    
-
-"""
+"""Alias harvesting metaclass used by :class:`aliaser.AliasMixin`."""
 
 
 class AliasMeta(type):


### PR DESCRIPTION
## Summary
- clean up boilerplate header in alias metaclass
- make `MultitonMeta` respect subclass overrides for `MULTITON_KEY_ATTR`
- validate key attribute existence and guard registry with a lock

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686c03758b14832d871ae522feebcbc5

## Summary by Sourcery

Streamline and harden the MultitonMeta metaclass and clean up AliasMeta documentation

Bug Fixes:
- Respect subclass overrides of MULTITON_KEY_ATTR
- Raise AttributeError when the target object lacks the required key attribute

Enhancements:
- Add a threading.Lock to guard the MultitonMeta instance registry for thread safety

Documentation:
- Replace the verbose boilerplate header in AliasMeta with a concise module-level docstring