### PR TITLE
V1.0.0 dev.4

### DIFF
--- a/aliaser/metaclass/alias.py
+++ b/aliaser/metaclass/alias.py
@@ -1,20 +1,4 @@
-"""
-
-
-Author: 
-    Inspyre Softworks
-
-Project:
-    aliaser
-
-File: 
-    aliaser/metaclass/alias.py
- 
-
-Description:
-    
-
-"""
+"""Alias harvesting metaclass used by :class:`aliaser.AliasMixin`."""
 
 
 class AliasMeta(type):


### PR DESCRIPTION
## Summary by Sourcery

Enhance MultitonMeta with thread-safe instance registry and stricter key attribute handling, and streamline AliasMeta documentation.

Enhancements:
- Add a threading lock to MultitonMeta to make instance lookup and creation thread-safe
- Enforce the presence of the specified MULTITON_KEY_ATTR on the device and remove fallback to repr
- Simplify MULTITON_KEY_ATTR initialization using getattr in the metaclass __init__

Documentation:
- Replace the verbose file header in AliasMeta with a concise module docstring